### PR TITLE
Add default keybinding to extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,13 @@
         "command": "extension.elixirJumpToTest",
         "title": "Elixir: Jump to test"
       }
+    ],
+    "keybindings": [
+      {
+        "command": "extension.elixirJumpToTest",
+        "key": "ctrl+shift+j",
+        "mac": "cmd+shift+j"
+      }
     ]
   },
   "scripts": {


### PR DESCRIPTION
solves #1 

this pull request updates the `package.json` file to include the default keybinding configuration for the extension

**extra details**:  the default binding is `ctrl+shift+j` for windows and linux and `cmd+shift+j` for mac
originally I was going to use `t` of test instead of `j` of jump but I changed it as it is less comfortable to press