### PR TITLE
Allow jumping from/to files on the `lib` folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.1.0] - 2019-10-02
 - Initial release
 
-## [Unreleased]
+## [0.2.0] - 2019-10-03
 - Add cmd + shift + j as keybinding
 - Add warning when user tries to jump from a file without a matching test
+- Fix the issue with files on the `lib` folder and umbrella apps

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This is a simple extension that makes you able to navigate between your elixir file and its test.
 
-It works as a charm with Phoenix Framework, but it wasn't tested with umbrella apps :thinking:
-
 No more Cmd + P for us!
 
 ## Features

--- a/extension.js
+++ b/extension.js
@@ -21,7 +21,8 @@ function activate(context) {
         return;
       }
 
-      const context = openedFile[2];
+      const context = openedFile[2] == '/lib/' ? '/test/' : openedFile[2].replace('/test/', '/lib/');
+
       const fileName = openedFile[3];
 
       const isTestFile = fileName.includes("_test");


### PR DESCRIPTION
closes #8 

it accidentally closes #5 too

# description
  to fix the issue mentioned above this PR changes the `context` constant when the current file is directly inside the `lib` folder or the `test` folder as those technically don't have a "context" of their own